### PR TITLE
add github workflows to publish preloads to github asssets

### DIFF
--- a/.github/workflows/preload-generator.yml
+++ b/.github/workflows/preload-generator.yml
@@ -1,0 +1,44 @@
+name: Preload Assets
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to upload assets to (default: latest release)"
+        required: false
+        default: "latest"
+      minikube_ref:
+        description: "minikube git ref to build from (default: HEAD)"
+        required: false
+        default: "HEAD"
+      limit:
+        description: "Value for --limit passed to preload-generator (default: 3)"
+        required: false
+        default: "3"
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event.inputs.release_tag || 'latest' }}
+      MINIKUBE_REF: ${{ github.event.inputs.minikube_ref || 'HEAD' }}
+      PRELOAD_LIMIT: ${{ github.event.inputs.limit || '3' }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout minikube-preloads
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22.x"
+
+      - name: Generate preloads and upload release assets
+        run: make release-preloads

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,59 @@ BIN := $(BIN_DIR)/minikube-preloads
 GOCACHE ?= $(CURDIR)/.cache/go-build
 GOMODCACHE ?= $(CURDIR)/.cache/go-mod
 
+# Settings for generating and uploading minikube preloads
+WORKDIR ?= $(CURDIR)/out/minikube-work
+ARTIFACT_DIR ?= $(CURDIR)/out/artifacts
+MINIKUBE_REPO ?= https://github.com/kubernetes/minikube.git
+MINIKUBE_REF ?= HEAD
+RELEASE_TAG ?= latest
+PRELOAD_LIMIT ?= 3
+GITHUB_REPOSITORY ?=
+
 .PHONY: build
 build:
 	@mkdir -p $(BIN_DIR) $(GOCACHE) $(GOMODCACHE)
 	GOCACHE=$(GOCACHE) GOMODCACHE=$(GOMODCACHE) go build -o $(BIN) ./cmd/preload-generator
+
+.PHONY: clean-workdir
+clean-workdir:
+	rm -rf $(WORKDIR)
+
+.PHONY: generate-preloads
+generate-preloads: clean-workdir
+	@mkdir -p $(WORKDIR) $(ARTIFACT_DIR)
+	git clone --filter=blob:none $(MINIKUBE_REPO) $(WORKDIR)
+	cd $(WORKDIR) && git fetch origin $(MINIKUBE_REF)
+	cd $(WORKDIR) && git checkout FETCH_HEAD
+	cd $(WORKDIR) && make update-kubeadm-constants
+	cd $(WORKDIR) && make out/minikube out/preload-generator
+	cd $(WORKDIR) && out/preload-generator --no-upload --limit $(PRELOAD_LIMIT)
+	@mkdir -p $(ARTIFACT_DIR)
+	@artifacts=$$(find $(WORKDIR)/out -maxdepth 1 -type f -name '*.lz4' -print); \
+	if [ -z "$$artifacts" ]; then \
+		echo "No .lz4 artifacts found in $(WORKDIR)/out"; \
+	else \
+		for f in $$artifacts; do \
+			mv "$$f" $(ARTIFACT_DIR)/; \
+		done; \
+	fi
+
+.PHONY: upload-preloads
+upload-preloads:
+	@test -n "$(GITHUB_TOKEN)" || (echo "GITHUB_TOKEN must be set for gh release upload" && exit 1)
+	@test -d "$(ARTIFACT_DIR)" || (echo "Artifact directory $(ARTIFACT_DIR) not found. Run generate-preloads first." && exit 1)
+	@artifacts=$$(find $(ARTIFACT_DIR) -type f); \
+	[ -n "$$artifacts" ] || (echo "No artifacts to upload from $(ARTIFACT_DIR)" && exit 1); \
+	repo=$(GITHUB_REPOSITORY); \
+	if [ -z "$$repo" ]; then \
+		repo=$$(gh repo view --json nameWithOwner --jq .nameWithOwner); \
+	fi; \
+	tag=$(RELEASE_TAG); \
+	if [ "$$tag" = "latest" ]; then \
+		tag=$$(gh release view --repo "$$repo" --json tagName --jq .tagName); \
+	fi; \
+	echo "Uploading assets to $$repo release $$tag"; \
+	gh release upload --repo "$$repo" --clobber "$$tag" $$artifacts
+
+.PHONY: release-preloads
+release-preloads: generate-preloads upload-preloads


### PR DESCRIPTION
- **add Makefile targets for generating and uploading minikube preloads**
- **add GitHub Actions workflow for generating and uploading preload assets**

part of https://github.com/kubernetes/minikube/issues/20887