### PR TITLE
use github as src in workfolw

### DIFF
--- a/.github/workflows/preload-generator.yml
+++ b/.github/workflows/preload-generator.yml
@@ -41,4 +41,4 @@ jobs:
           go-version: "1.22.x"
 
       - name: Generate preloads and upload release assets
-        run: make release-preloads
+        run: make release-preloads-github

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,10 @@ upload-preloads:
 	@test -n "$(GITHUB_TOKEN)" || (echo "GITHUB_TOKEN must be set for gh release upload" && exit 1)
 	@test -d "$(ARTIFACT_DIR)" || (echo "Artifact directory $(ARTIFACT_DIR) not found. Run generate-preloads first." && exit 1)
 	@artifacts=$$(find $(ARTIFACT_DIR) -type f); \
-	[ -n "$$artifacts" ] || (echo "No artifacts to upload from $(ARTIFACT_DIR)" && exit 1); \
+	if [ -z "$$artifacts" ]; then \
+		echo "No artifacts to upload from $(ARTIFACT_DIR); skipping upload"; \
+		exit 0; \
+	fi; \
 	repo=$(GITHUB_REPOSITORY); \
 	if [ -z "$$repo" ]; then \
 		repo=$$(gh repo view --json nameWithOwner --jq .nameWithOwner); \


### PR DESCRIPTION
- **improve upload-preloads target to skip upload if no artifacts are found**
- **Makefile and workflow to use GitHub-specific preload generation and upload targets**

part of parent issue https://github.com/kubernetes/minikube/issues/20887