### PR TITLE
ci: use fullsha for github actions

### DIFF
--- a/.github/workflows/preload-generator.yml
+++ b/.github/workflows/preload-generator.yml
@@ -45,10 +45,10 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout minikube-preloads
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Generate preloads and upload release assets


### PR DESCRIPTION
The kubernetes-sigs org policy requires all actions to be pinned to full-length commit SHAs. The workflow was using mutable tag refs (@v4, @v6), causing CI to fail.

Changes
.github/workflows/preload-generator.yml
actions/checkout@v4 → pinned to full SHA (v4.3.1)
actions/setup-go@v6 → pinned to full SHA (v6.4.0)
- uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
- uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0


closes https://github.com/kubernetes-sigs/minikube-preloads/issues/22