### PR TITLE
prioritize newer minor versions and latest patches in preloads generation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,27 @@
+name: PR Check
+
+on:
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  test-and-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version: '1.25.x'
+          cache: true
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: make test
+
+      - name: Run lint
+        run: make lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,10 +2,10 @@ name: PR Check
 
 on:
   pull_request:
-    branches: [ master, main ]
+    branches: [ main ]
 
 jobs:
-  test-and-lint:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -14,14 +14,24 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          go-version: '1.25.x'
+          go-version-file: 'go.mod'
           cache: true
-
-      - name: Install dependencies
-        run: go mod download
 
       - name: Run tests
         run: make test
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
       - name: Run lint
         run: make lint
+

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,12 @@ build:
 	@mkdir -p $(BIN_DIR) $(GOCACHE) $(GOMODCACHE)
 	GOCACHE=$(GOCACHE) GOMODCACHE=$(GOMODCACHE) go build -o $(BIN) ./cmd/preload-generator
 
+.PHONY: test
+test:
+	@mkdir -p $(GOCACHE) $(GOMODCACHE)
+	GOCACHE=$(GOCACHE) GOMODCACHE=$(GOMODCACHE) go test -v ./...
+
+
 .PHONY: clean-workdir
 clean-workdir:
 	rm -rf $(WORKDIR)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOLINT_VERSION ?= v2.7.2
+GOLINT_VERSION ?= v2.11.4
 # see https://golangci-lint.run/docs/configuration/file/ for config details
 GOLINT_CONFIG ?= .golangci.min.yaml
 # Set this to --verbose to see details about the linters and formatters used

--- a/cmd/preload-generator/preload_images.go
+++ b/cmd/preload-generator/preload_images.go
@@ -301,10 +301,10 @@ func prioritizeVersions(versions []string, recentMinors int, priority3Limit int)
 		return versions
 	}
 
-	// Find max minor version
+	// Find max stable minor version
 	var maxMinor uint64
 	for _, pv := range parsed {
-		if pv.sem.Major == 1 {
+		if pv.sem.Major == 1 && len(pv.sem.Pre) == 0 {
 			if pv.sem.Minor > maxMinor {
 				maxMinor = pv.sem.Minor
 			}

--- a/cmd/preload-generator/preload_images.go
+++ b/cmd/preload-generator/preload_images.go
@@ -275,13 +275,16 @@ type parsedVersion struct {
 
 // prioritizeVersions sorts K8s version strings based on three priorities:
 //
-//   - Priority 1: The past 5 minor versions (including the newest found minor version)
-//     and all their patches (e.g., if newest is v1.36, then v1.36.x to v1.32.x), ordered descending.
+//   - Priority 1: The past `recentMinors` minor versions (including the newest found
+//     minor version) and all their patches (e.g., if `recentMinors=5` and newest is
+//     v1.36, then v1.36.x to v1.32.x), ordered descending. If `recentMinors <= 0`,
+//     Priority 1 will be completely empty.
 //
 //   - Priority 2: The latest (highest) patch of any older minor version (e.g., v1.31.14, v1.30.14),
 //     ordered descending by minor version.
 //
-// - Priority 3: All other patches of older minor versions, ordered descending.
+//   - Priority 3: All other patches of older minor versions, ordered descending and
+//     capped to `priority3Limit` if greater than 0.
 func prioritizeVersions(versions []string, recentMinors int, priority3Limit int) []string {
 	var parsed []parsedVersion
 	for _, v := range versions {
@@ -309,10 +312,14 @@ func prioritizeVersions(versions []string, recentMinors int, priority3Limit int)
 	}
 
 	var cutoffMinor uint64
-	if recentMinors > 0 && maxMinor >= uint64(recentMinors-1) {
-		cutoffMinor = maxMinor - uint64(recentMinors-1)
+	if recentMinors > 0 {
+		if maxMinor >= uint64(recentMinors-1) {
+			cutoffMinor = maxMinor - uint64(recentMinors-1)
+		} else {
+			cutoffMinor = 0
+		}
 	} else {
-		cutoffMinor = 0
+		cutoffMinor = maxMinor + 1
 	}
 
 	var priority1 []parsedVersion

--- a/cmd/preload-generator/preload_images.go
+++ b/cmd/preload-generator/preload_images.go
@@ -25,10 +25,12 @@ import (
 	"os"
 	"os/exec"
 	"runtime/debug"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
 
+	"github.com/blang/semver/v4"
 	"github.com/spf13/viper"
 	"k8s.io/minikube/pkg/minikube/constants"
 	"k8s.io/minikube/pkg/minikube/download"
@@ -53,6 +55,8 @@ var (
 	armUpload             = flag.Bool("arm-upload", false, "Upload the arm64 preload tarballs to GCS")
 	armPreloadsDir        = flag.String("arm-preloads-dir", "artifacts", "Directory containing the arm64 preload tarballs")
 	preloadSrc            = flag.String("preload-src", "gcs", "Source to check for existing preloads (gcs|gh)")
+	recentMinors          = flag.Int("recent-minors", 5, "Number of recent minor Kubernetes versions to prioritize and generate all patches for")
+	priority3Limit        = flag.Int("priority-3-limit", 3, "Maximum number of Priority 3 versions (older patches of older minor versions) to keep. If 0, all of them will be kept.")
 )
 
 type preloadCfg struct {
@@ -153,7 +157,8 @@ func collectK8sVers() ([]string, error) {
 		constants.NewestKubernetesVersion,
 		constants.OldestKubernetesVersion,
 	}, k8sVersions...)
-	return util.RemoveDuplicateStrings(versions), nil
+	unique := util.RemoveDuplicateStrings(versions)
+	return prioritizeVersions(unique, *recentMinors, *priority3Limit), nil
 }
 
 func makePreload(cfg preloadCfg) error {
@@ -261,4 +266,125 @@ func exit(msg string, err error) {
 		fmt.Printf("error cleaning up minikube at start up: %v\n", err)
 	}
 	os.Exit(60)
+}
+
+type parsedVersion struct {
+	raw string
+	sem semver.Version
+}
+
+// prioritizeVersions sorts K8s version strings based on three priorities:
+//
+//   - Priority 1: The past 5 minor versions (including the newest found minor version)
+//     and all their patches (e.g., if newest is v1.36, then v1.36.x to v1.32.x), ordered descending.
+//
+//   - Priority 2: The latest (highest) patch of any older minor version (e.g., v1.31.14, v1.30.14),
+//     ordered descending by minor version.
+//
+// - Priority 3: All other patches of older minor versions, ordered descending.
+func prioritizeVersions(versions []string, recentMinors int, priority3Limit int) []string {
+	var parsed []parsedVersion
+	for _, v := range versions {
+		clean := strings.TrimPrefix(v, "v")
+		sv, err := semver.Parse(clean)
+		if err != nil {
+			log.Printf("Warning: failed to parse version %q: %v", v, err)
+			continue
+		}
+		parsed = append(parsed, parsedVersion{raw: v, sem: sv})
+	}
+
+	if len(parsed) == 0 {
+		return versions
+	}
+
+	// Find max minor version
+	var maxMinor uint64
+	for _, pv := range parsed {
+		if pv.sem.Major == 1 {
+			if pv.sem.Minor > maxMinor {
+				maxMinor = pv.sem.Minor
+			}
+		}
+	}
+
+	var cutoffMinor uint64
+	if recentMinors > 0 && maxMinor >= uint64(recentMinors-1) {
+		cutoffMinor = maxMinor - uint64(recentMinors-1)
+	} else {
+		cutoffMinor = 0
+	}
+
+	var priority1 []parsedVersion
+	// Map from minor version to all its parsed versions (for minor < cutoffMinor)
+	olderGroups := make(map[uint64][]parsedVersion)
+
+	for _, pv := range parsed {
+		if pv.sem.Major != 1 {
+			olderGroups[pv.sem.Minor] = append(olderGroups[pv.sem.Minor], pv)
+			continue
+		}
+
+		if pv.sem.Minor >= cutoffMinor {
+			priority1 = append(priority1, pv)
+		} else {
+			olderGroups[pv.sem.Minor] = append(olderGroups[pv.sem.Minor], pv)
+		}
+	}
+
+	// Sort Priority 1 descending
+	sort.Slice(priority1, func(i, j int) bool {
+		return priority1[i].sem.GT(priority1[j].sem)
+	})
+
+	// Process older groups to extract Priority 2 and Priority 3
+	var priority2 []parsedVersion
+	var priority3 []parsedVersion
+
+	// Get older minor versions in descending order
+	var olderMinors []uint64
+	for m := range olderGroups {
+		olderMinors = append(olderMinors, m)
+	}
+	sort.Slice(olderMinors, func(i, j int) bool {
+		return olderMinors[i] > olderMinors[j]
+	})
+
+	for _, m := range olderMinors {
+		group := olderGroups[m]
+		// Sort group descending
+		sort.Slice(group, func(i, j int) bool {
+			return group[i].sem.GT(group[j].sem)
+		})
+
+		// First is the highest patch of this minor version
+		priority2 = append(priority2, group[0])
+		// The rest go to Priority 3
+		if len(group) > 1 {
+			priority3 = append(priority3, group[1:]...)
+		}
+	}
+
+	// Sort Priority 3 descending
+	sort.Slice(priority3, func(i, j int) bool {
+		return priority3[i].sem.GT(priority3[j].sem)
+	})
+
+	if priority3Limit > 0 && len(priority3) > priority3Limit {
+		priority3 = priority3[:priority3Limit]
+	}
+
+	// Concatenate all priorities
+	var result []string
+	for _, pv := range priority1 {
+		result = append(result, pv.raw)
+	}
+	for _, pv := range priority2 {
+		result = append(result, pv.raw)
+	}
+	for _, pv := range priority3 {
+		result = append(result, pv.raw)
+	}
+
+	return result
 }

--- a/cmd/preload-generator/preload_images_test.go
+++ b/cmd/preload-generator/preload_images_test.go
@@ -72,3 +72,94 @@ func TestParseContainerdSnapshotterCases(t *testing.T) {
 		})
 	}
 }
+
+func TestPrioritizeVersions(t *testing.T) {
+	input := []string{
+		"v1.30.12",
+		"v1.36.0",
+		"v1.31.14",
+		"v1.35.4",
+		"v1.29.15",
+		"v1.35.0-rc.1",
+		"v1.30.14",
+		"v1.32.1",
+		"v1.31.13",
+		"v1.28.0",
+		"v1.32.0",
+	}
+
+	t.Run("recentMinors=5, priority3Limit=0", func(t *testing.T) {
+		want := []string{
+			"v1.36.0",
+			"v1.35.4",
+			"v1.35.0-rc.1",
+			"v1.32.1",
+			"v1.32.0",
+			"v1.31.14",
+			"v1.30.14",
+			"v1.29.15",
+			"v1.28.0",
+			"v1.31.13",
+			"v1.30.12",
+		}
+		got := prioritizeVersions(input, 5, 0)
+		if len(got) != len(want) {
+			t.Fatalf("got length %d, want %d", len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("at index %d: got %s, want %s", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("recentMinors=5, priority3Limit=1", func(t *testing.T) {
+		want := []string{
+			"v1.36.0",
+			"v1.35.4",
+			"v1.35.0-rc.1",
+			"v1.32.1",
+			"v1.32.0",
+			"v1.31.14",
+			"v1.30.14",
+			"v1.29.15",
+			"v1.28.0",
+			"v1.31.13",
+		}
+		got := prioritizeVersions(input, 5, 1)
+		if len(got) != len(want) {
+			t.Fatalf("got length %d, want %d", len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("at index %d: got %s, want %s", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("recentMinors=3, priority3Limit=2", func(t *testing.T) {
+		want := []string{
+			"v1.36.0",
+			"v1.35.4",
+			"v1.35.0-rc.1",
+			"v1.32.1",
+			"v1.31.14",
+			"v1.30.14",
+			"v1.29.15",
+			"v1.28.0",
+			"v1.32.0",
+			"v1.31.13",
+		}
+		got := prioritizeVersions(input, 3, 2)
+		if len(got) != len(want) {
+			t.Fatalf("got length %d, want %d", len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("at index %d: got %s, want %s", i, got[i], want[i])
+			}
+		}
+	})
+}
+
+

--- a/cmd/preload-generator/preload_images_test.go
+++ b/cmd/preload-generator/preload_images_test.go
@@ -183,6 +183,47 @@ func TestPrioritizeVersions(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("recentMinors=5, ignorePrereleaseForMaxMinor", func(t *testing.T) {
+		inputWithPrerelease := []string{
+			"v1.36.0",
+			"v1.35.4",
+			"v1.37.0-rc.0", // pre-release of newer minor version
+			"v1.32.1",
+			"v1.32.0",
+			"v1.31.14",
+			"v1.31.13",
+		}
+		// Max stable minor is 36. Cutoff minor is 36 - 4 = 32.
+		// Priority 1 (>= 1.32.0):
+		//   v1.37.0-rc.0
+		//   v1.36.0
+		//   v1.35.4
+		//   v1.32.1
+		//   v1.32.0
+		// Priority 2 (highest patch of older minor versions < 32):
+		//   v1.31.14 (for 1.31)
+		// Priority 3 (other patches of older minor versions < 32):
+		//   v1.31.13 (for 1.31)
+		want := []string{
+			"v1.37.0-rc.0",
+			"v1.36.0",
+			"v1.35.4",
+			"v1.32.1",
+			"v1.32.0",
+			"v1.31.14",
+			"v1.31.13",
+		}
+		got := prioritizeVersions(inputWithPrerelease, 5, 0)
+		if len(got) != len(want) {
+			t.Fatalf("got length %d, want %d", len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("at index %d: got %s, want %s", i, got[i], want[i])
+			}
+		}
+	})
 }
 
 

--- a/cmd/preload-generator/preload_images_test.go
+++ b/cmd/preload-generator/preload_images_test.go
@@ -160,6 +160,29 @@ func TestPrioritizeVersions(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("recentMinors=0, priority3Limit=2", func(t *testing.T) {
+		want := []string{
+			"v1.36.0",
+			"v1.35.4",
+			"v1.32.1",
+			"v1.31.14",
+			"v1.30.14",
+			"v1.29.15",
+			"v1.28.0",
+			"v1.35.0-rc.1",
+			"v1.32.0",
+		}
+		got := prioritizeVersions(input, 0, 2)
+		if len(got) != len(want) {
+			t.Fatalf("got length %d, want %d", len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("at index %d: got %s, want %s", i, got[i], want[i])
+			}
+		}
+	})
 }
 
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module sigs.k8s.io/minikube-preloads
 
-go 1.25.0
+go 1.26.0
+
 
 replace github.com/docker/machine => github.com/minikube-machine/machine v0.0.0-20240815173309-ffb6b643c381
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 replace github.com/docker/machine => github.com/minikube-machine/machine v0.0.0-20240815173309-ffb6b643c381
 
 require (
+	github.com/blang/semver/v4 v4.0.0
 	github.com/google/go-github/v79 v79.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/viper v1.21.0
@@ -51,7 +52,6 @@ require (
 	github.com/aws/smithy-go v1.22.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/briandowns/spinner v1.23.2 // indirect
 	github.com/c4milo/gotoolkit v0.0.0-20190525173301-67483a18c17a // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect


### PR DESCRIPTION
This PR implements a three-tier Kubernetes version prioritization algorithm for the preloads generator script. This ensures that critical/modern versions are processed first, while older patch releases are deferred or capped to optimize GCS storage and execution time.

Prioritization Sorting Tiers:
Priority 1 (Newest Minor Releases): All patches belonging to the past recent-minors versions (default 5 minor versions, e.g., 1.36.x to 1.32.x), sorted descending.
Priority 2 (Older Minor Releases - Latest Patch): The highest patch of each older minor version (e.g., v1.31.14, v1.30.14), sorted descending.
Priority 3 (Older Minor Releases - Older Patches): All remaining older patches, sorted descending and capped to priority-3-limit (default 3 versions; set to 0 to generate all).


closes https://github.com/kubernetes-sigs/minikube-preloads/issues/21